### PR TITLE
Handle id-prefixed arguments in processkill command

### DIFF
--- a/Commands/CommandRegistry.cs
+++ b/Commands/CommandRegistry.cs
@@ -230,8 +230,8 @@ public static class CommandRegistry
                 {
                     if (model.Args[0].StartsWith("id:", StringComparison.OrdinalIgnoreCase))
                     {
-                        string procStr = model.Args[0][0..].Trim();
-                        if (int.TryParse(procStr, out int procId))
+                        string procStr = model.Args[0][3..].Trim();
+                        if (!string.IsNullOrEmpty(procStr) && int.TryParse(procStr, out int procId))
                         {
                             Process.GetProcessById(procId).Kill();
                             await Program.SendSuccessAsync(model.Message, "Process killed successfully.");


### PR DESCRIPTION
## Summary
- trim the id: prefix when parsing the /processkill command arguments
- validate the extracted process identifier before attempting to kill the process

## Testing
- Not Run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f689094950832b805f12bf8c3ff1e2