### PR TITLE
Add supervised restart loop and graceful shutdown for bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ This version is based on the [Garneg's TelegramRAT](https://github.com/Garneg/Te
 4. Deploy the compiled binary on the target system.
 5. Start the application and control it through your Telegram bot.
 
+## Runtime behavior
+
+`TelegramRAT` supervises the polling loop and automatically recreates the Telegram client if an unexpected error occurs. Each retry clears any cached command state, notifies the configured owner about the failure, and waits with an exponential backoff (up to 60 seconds) before reconnecting. Pressing <kbd>Ctrl</kbd> + <kbd>C</kbd> requests a graceful shutdown so the bot can stop polling without forcing another restart.
+
 ## Configuration
 
 `TelegramRAT` reads its runtime configuration from **environment variables** or an optional `appsettings.json` file located next to the executable. Environment variables have priority; any value that is missing falls back to `appsettings.json`.


### PR DESCRIPTION
## Summary
- replace the recursive restart logic in `Program.Main` with a supervised loop that rebuilds the Telegram client between attempts and respects console cancellation
- add helper routines that detect conflicting polling sessions, notify the owner about failures, clear commands, and back off before retrying
- update runtime documentation to describe the restart and shutdown behaviour

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f6a96e1998832ba7ba5c4b8b0d9a06