### PR TITLE
Make help arguments optional

### DIFF
--- a/Commands/CommandRegistry.cs
+++ b/Commands/CommandRegistry.cs
@@ -88,7 +88,7 @@ public static class CommandRegistry
             Command = "help",
             Description = "Show description of other commands.",
             Example = "/help screenshot",
-            ArgsCount = 1,
+            ArgsCount = -1,
             Execute = async model =>
             {
                 if (!model.Args.Any())


### PR DESCRIPTION
## Summary
- allow the /help command to accept zero or one arguments by marking its argument count optional

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f745d1d2f8832b93be1bc62e298ffc