### PR TITLE
Require arguments for processkill command

### DIFF
--- a/Commands/CommandRegistry.cs
+++ b/Commands/CommandRegistry.cs
@@ -241,6 +241,7 @@ public static class CommandRegistry
         commandsList.Add(new BotCommand
         {
             Command = "processkill",
+            ArgsCount = -2,
             Description = "Kill process or processes by name or id.",
             Example = "/processkill id:1234",
             Execute = async model =>


### PR DESCRIPTION
## Summary
- require at least one argument when executing the `/processkill` command to avoid indexing empty argument lists

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f74bc21ea4832ba5c306fefea95551