### PR TITLE
Fix virtual screen handling

### DIFF
--- a/Commands/CommandRegistry.cs
+++ b/Commands/CommandRegistry.cs
@@ -907,8 +907,10 @@ public static class CommandRegistry
                             return;
 
                         case "to":
-                            mouseSimulator.MoveMouseTo(Convert.ToDouble(model.Args[1]) * (ushort.MaxValue / WinAPI.GetScreenBounds().Width),
-                            Convert.ToDouble(model.Args[2]) * (ushort.MaxValue / WinAPI.GetScreenBounds().Height));
+                            Rectangle virtualBounds = WinAPI.GetScreenBounds();
+                            double normalizedX = (Convert.ToDouble(model.Args[1]) - virtualBounds.X) * ((double)ushort.MaxValue / virtualBounds.Width);
+                            double normalizedY = (Convert.ToDouble(model.Args[2]) - virtualBounds.Y) * ((double)ushort.MaxValue / virtualBounds.Height);
+                            mouseSimulator.MoveMouseTo(normalizedX, normalizedY);
                             responseSent = true;
                             await Program.Bot.SendMessage(model.Message.Chat.Id, "Done!", replyParameters: new ReplyParameters { MessageId = model.Message.MessageId });
                             break;
@@ -1129,7 +1131,7 @@ public static class CommandRegistry
                     using Bitmap bitmap = new Bitmap(bounds.Width, bounds.Height);
                     using Graphics graphics = Graphics.FromImage(bitmap);
                     using MemoryStream screenshotStream = new MemoryStream();
-                    graphics.CopyFromScreen(System.Drawing.Point.Empty, System.Drawing.Point.Empty, bounds.Size);
+                    graphics.CopyFromScreen(bounds.Location, Point.Empty, bounds.Size);
 
                     bitmap.Save(screenshotStream, ImageFormat.Png);
 

--- a/Utilities/WinAPI.cs
+++ b/Utilities/WinAPI.cs
@@ -43,13 +43,20 @@ static class WinAPI
         SM_CYSCREEN = 1,
         SM_CXFULLSCREEN = 16,
         SM_CYFULLSCREEN = 17,
+        SM_XVIRTUALSCREEN = 76,
+        SM_YVIRTUALSCREEN = 77,
         SM_CXVIRTUALSCREEN = 78,
         SM_CYVIRTUALSCREEN = 79
     }
 
     public static Rectangle GetScreenBounds()
     {
-        return new Rectangle(0, 0, GetSystemMetrics((int)MetricsIndexes.SM_CXVIRTUALSCREEN), GetSystemMetrics((int)MetricsIndexes.SM_CYSCREEN));
+        int originX = GetSystemMetrics((int)MetricsIndexes.SM_XVIRTUALSCREEN);
+        int originY = GetSystemMetrics((int)MetricsIndexes.SM_YVIRTUALSCREEN);
+        int width = GetSystemMetrics((int)MetricsIndexes.SM_CXVIRTUALSCREEN);
+        int height = GetSystemMetrics((int)MetricsIndexes.SM_CYVIRTUALSCREEN);
+
+        return new Rectangle(originX, originY, width, height);
     }
 
 


### PR DESCRIPTION
## Summary
- update WinAPI screen metric constants to include virtual screen origin and return the full virtual bounds
- capture screenshots using the virtual screen origin so all monitors are included
- normalize mouse move targets relative to the virtual screen origin to ensure accurate cursor positioning

## Testing
- ⚠️ `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f7c8288bdc832b8fa237d49202384b